### PR TITLE
Generate audio scripts at runtime

### DIFF
--- a/Assets/TVModule.prefab
+++ b/Assets/TVModule.prefab
@@ -169,12 +169,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4358605278943704}
   - component: {fileID: 328193985374121160}
-  - component: {fileID: 82785071623154846}
-  - component: {fileID: 82485002903727868}
-  - component: {fileID: 82667666698415524}
-  - component: {fileID: 114700331514443894}
-  - component: {fileID: 114887377247630468}
-  - component: {fileID: 114233633027875880}
   m_Layer: 0
   m_Name: Video Player
   m_TagString: Untagged
@@ -1273,246 +1267,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1028744697617550}
   m_Mesh: {fileID: 4300010, guid: b28ef2f391c51f7429981be966e909e8, type: 3}
---- !u!82 &82485002903727868
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1426540707143226}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    - serializedVersion: 2
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
---- !u!82 &82667666698415524
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1426540707143226}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 8300000, guid: 26e165616cafe3148973b572fde95ce2, type: 3}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 1
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    - serializedVersion: 2
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
---- !u!82 &82785071623154846
-AudioSource:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1426540707143226}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    - serializedVersion: 2
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 2
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
 --- !u!95 &95707106575032282
 Animator:
   serializedVersion: 3
@@ -1720,20 +1474,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   HighlightScale: {x: 1, y: 1, z: 1}
   OutlineAmount: 0
---- !u!114 &114233633027875880
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1426540707143226}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1452013704, guid: 91a38c1de9502d94782f34ced7217b09, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _isSFX: 1
-  _audioClips: []
-  _audioSource: {fileID: 82667666698415524}
 --- !u!114 &114257655999471088
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1809,9 +1549,7 @@ MonoBehaviour:
     m_PostInfinity: 0
     m_RotationOrder: 0
   Player: {fileID: 328193985374121160}
-  Source1: {fileID: 114700331514443894}
-  Source2: {fileID: 114887377247630468}
-  SourceStatic: {fileID: 114233633027875880}
+  staticAudio: {fileID: 8300000, guid: 26e165616cafe3148973b572fde95ce2, type: 3}
   staticMat: {fileID: 23401483537835428}
   buttonVol: {fileID: 114830000838779960}
   buttonPow: {fileID: 114660128626198046}
@@ -1958,20 +1696,6 @@ MonoBehaviour:
   AllowSelectionWrapY: 0
   ForceSelectionHighlight: 0
   ForceInteractionHighlight: 0
---- !u!114 &114700331514443894
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1426540707143226}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1452013704, guid: 91a38c1de9502d94782f34ced7217b09, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _isSFX: 1
-  _audioClips: []
-  _audioSource: {fileID: 82785071623154846}
 --- !u!114 &114751597348016014
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2077,20 +1801,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   HighlightScale: {x: 1, y: 1, z: 1}
   OutlineAmount: 0
---- !u!114 &114887377247630468
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1426540707143226}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1452013704, guid: 91a38c1de9502d94782f34ced7217b09, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _isSFX: 1
-  _audioClips: []
-  _audioSource: {fileID: 82485002903727868}
 --- !u!328 &328193985374121160
 VideoPlayer:
   m_ObjectHideFlags: 1

--- a/Assets/TVScript.cs
+++ b/Assets/TVScript.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.Video;
@@ -8,7 +9,7 @@ public class TVScript : MonoBehaviour
     public GameObject RigFab;
     public AnimationCurve WobbleCurve;
     public VideoPlayer Player;
-    public AudioScript Source1, Source2, SourceStatic;
+    public AudioClip staticAudio;
     public MeshRenderer staticMat;
     public KMSelectable buttonVol, buttonPow, buttonBrg, buttonCon, buttonChn;
     public GameObject staticScreen, videoScreen, blackScreen;
@@ -24,12 +25,12 @@ public class TVScript : MonoBehaviour
     private float volume = 0.1f;
 
     private static VideoClip[] clips = new VideoClip[0];
+    private AudioScript source1, source2, sourceStatic;
     private int currentClip = 1;
 
     private bool _solved = false;
 
     private CameraRig Rig;
-
     void Start()
     {
         GameObject c = Instantiate(RigFab);
@@ -64,18 +65,23 @@ public class TVScript : MonoBehaviour
         //camera.fieldOfView *= transform.lossyScale.x;
         //camera.farClipPlane *= transform.lossyScale.y;
         Player.clip = clips[1];
-        Player.SetTargetAudioSource(0, Source1.AudioSource);
-        Player.SetTargetAudioSource(1, Source2.AudioSource);
-        Source1.Volume = volume;
-        Source2.Volume = volume;
-        SourceStatic.Volume = volume;
+        GameObject playerObject = Player.gameObject;
+        source1 = playerObject.AddComponent<AudioScript>();
+        source2 = playerObject.AddComponent<AudioScript>();
+        sourceStatic = playerObject.AddComponent<AudioScript>();
+        sourceStatic.AudioSource.clip = staticAudio;
+        Player.SetTargetAudioSource(0, source1.AudioSource);
+        Player.SetTargetAudioSource(1, source2.AudioSource);
+        source1.Volume = volume;
+        source2.Volume = volume;
+        sourceStatic.Volume = volume;
         Player.Play();
-        SourceStatic.AudioSource.Play();
+        sourceStatic.AudioSource.Play();
 
         Player.isLooping = true;
         Player.loopPointReached += NextVideo;
 
-        buttonVol.OnInteract += () => { buttonVol.AddInteractionPunch(0.1f); volume += 0.1f; volume %= 1f; Source1.Volume = volume; Source2.Volume = volume; SourceStatic.Volume = volume; return false; };
+        buttonVol.OnInteract += () => { buttonVol.AddInteractionPunch(0.1f); volume += 0.1f; volume %= 1f; source1.Volume = volume; source2.Volume = volume; sourceStatic.Volume = volume; return false; };
         buttonPow.OnInteract += () => { buttonPow.AddInteractionPunch(0.1f); Power(); return false; };
         buttonChn.OnInteract += () => { buttonChn.AddInteractionPunch(0.1f); Channel(); return false; };
         Power();
@@ -156,27 +162,27 @@ public class TVScript : MonoBehaviour
         switch(screenMode)
         {
             case 2:
-                Source1.AudioSource.mute = true;
-                Source2.AudioSource.mute = true;
-                SourceStatic.AudioSource.mute = false;
+                source1.AudioSource.mute = true;
+                source2.AudioSource.mute = true;
+                sourceStatic.AudioSource.mute = false;
                 staticScreen.transform.localPosition = new Vector3(0f, 0f, 0f);
                 videoScreen.transform.localPosition = new Vector3(0f, 0f, -0.1f);
                 blackScreen.transform.localPosition = new Vector3(0f, 0f, -0.1f);
                 Player.Stop();
                 break;
             case 3:
-                Source1.AudioSource.mute = false;
-                Source2.AudioSource.mute = false;
-                SourceStatic.AudioSource.mute = true;
+                source1.AudioSource.mute = false;
+                source2.AudioSource.mute = false;
+                sourceStatic.AudioSource.mute = true;
                 staticScreen.transform.localPosition = new Vector3(0f, 0f, -0.1f);
                 videoScreen.transform.localPosition = new Vector3(0f, 0f, 0f);
                 blackScreen.transform.localPosition = new Vector3(0f, 0f, -0.1f);
                 Player.Play();
                 break;
             default:
-                Source1.AudioSource.mute = true;
-                Source2.AudioSource.mute = true;
-                SourceStatic.AudioSource.mute = true;
+                source1.AudioSource.mute = true;
+                source2.AudioSource.mute = true;
+                sourceStatic.AudioSource.mute = true;
                 staticScreen.transform.localPosition = new Vector3(0f, 0f, -0.1f);
                 videoScreen.transform.localPosition = new Vector3(0f, 0f, -0.1f);
                 blackScreen.transform.localPosition = new Vector3(0f, 0f, 0f);
@@ -215,9 +221,9 @@ public class TVScript : MonoBehaviour
     IEnumerator ProcessTwitchCommand(string command)
     {
         volume = 0f;
-        Source1.Volume = volume;
-        Source2.Volume = volume;
-        SourceStatic.Volume = volume;
+        source1.Volume = volume;
+        source2.Volume = volume;
+        sourceStatic.Volume = volume;
 
         command = command.Trim().ToLowerInvariant();
         Match m;


### PR DESCRIPTION
For some reason, loading certain KeepCoding modules after TV have a chance to nullify all of the AudioScript components that are present in the module. At the moment, there is no way of fixing this, so I removed all of the AudioScripts and AudioSources from the videoplayer, and now the components are added when the module is initialized.

This is not a proper fix, and I do not know if a proper fix is possible. But for the time being, all audio will be controlled by the game's music, due to me not being able to access KeepCoding's _isSFX variable.